### PR TITLE
Insert before ActionDispatch::Static if available

### DIFF
--- a/lib/font_assets/railtie.rb
+++ b/lib/font_assets/railtie.rb
@@ -8,7 +8,13 @@ module FontAssets
       config.font_assets.origin ||= "*"
       config.font_assets.options ||= { allow_ssl: true }
 
-      app.middleware.insert_before 'Rack::Lock', FontAssets::Middleware, config.font_assets.origin, config.font_assets.options
+      insert_target = if defined?(ActionDispatch::Static)
+        'ActionDispatch::Static'
+      else
+        'Rack::Lock'
+      end
+
+      app.middleware.insert_before insert_target, FontAssets::Middleware, config.font_assets.origin, config.font_assets.options
     end
   end
 end


### PR DESCRIPTION
Currently font_assets doesn't work with precompiled assets on Heroku because it's inserted after `ActionDispatch::Static`, which serves `/public` and precompiled assets in the absence of a standard web server. This pull changes the insert point to `ActionDispatch::Static` if it exists. This hits a very, very common Heroku use case and would solve i.e. rubymaverick/font_assets#10 and rubymaverick/font_assets#13.

`ActionDispatch::Static` is directly above `Rack::Cache` in the middleware stack, so this otherwise changes behavior very little.
