### PR TITLE
Fix bug where a wildcard origin served over https would become https://*

### DIFF
--- a/lib/font_assets/middleware.rb
+++ b/lib/font_assets/middleware.rb
@@ -36,13 +36,17 @@ module FontAssets
     private
 
     def origin
-      if allow_ssl? and ssl_request?
+      if !wildcard_origin? and allow_ssl? and ssl_request?
         uri = URI(@origin)
         uri.scheme = "https"
         uri.to_s
       else
         @origin
       end
+    end
+
+    def wildcard_origin?
+      @origin == '*'
     end
 
     def ssl_request?

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -39,7 +39,39 @@ describe FontAssets::Middleware do
             its(['Content-Type']) { should == 'application/x-font-ttf' }
           end
         end
-        
+
+      end
+
+      context 'with an app that allows ssl from any origin' do
+        let(:app) { load_app '*', allow_ssl: true }
+
+        context 'and makes an https request' do
+          let(:response) { request app, 'https://test.origin/test.ttf' }
+
+          context 'the response headers' do
+            subject { response[1] }
+
+            its(["Access-Control-Allow-Headers"]) { should == "x-requested-with" }
+            its(["Access-Control-Max-Age"]) { should == "3628800" }
+            its(['Access-Control-Allow-Methods']) { should == 'GET' }
+            its(['Access-Control-Allow-Origin']) { should == '*' }
+            its(['Content-Type']) { should == 'application/x-font-ttf' }
+          end
+        end
+
+        context 'and makes an http request' do
+          let(:response) { request app, 'http://test.origin/test.ttf' }
+
+          context 'the response headers' do
+            subject { response[1] }
+
+            its(["Access-Control-Allow-Headers"]) { should == "x-requested-with" }
+            its(["Access-Control-Max-Age"]) { should == "3628800" }
+            its(['Access-Control-Allow-Methods']) { should == 'GET' }
+            its(['Access-Control-Allow-Origin']) { should == '*' }
+            its(['Content-Type']) { should == 'application/x-font-ttf' }
+          end
+        end
       end
 
       context 'with an app with just the origin specified' do


### PR DESCRIPTION
The FF CDN fonts issue this gem solves had eaten away a few hours of my day today ... until I finally found your gem! Super useful, thanks!

I have an app that uses precompiled assets on Heroku served over SSL and CloudFront. When I first deployed with default settings, I noticed the origin was being set to https://*. I fixed it temporarily in the current version of the gem by configuring an explicit origin uri. This pull request allows the precompiled SSL scenario to work by default without any additional configuration.
