### PR TITLE
Fix for apps that will change env['PATH_INFO']

### DIFF
--- a/lib/font_assets/middleware.rb
+++ b/lib/font_assets/middleware.rb
@@ -26,8 +26,9 @@ module FontAssets
       if env["REQUEST_METHOD"] == "OPTIONS"
         return [200, access_control_headers, []]
       else
+        path = env["PATH_INFO"].dup
         code, headers, body = @app.call(env)
-        set_headers! headers, body, env["PATH_INFO"]
+        set_headers! headers, body, path
         [code, headers, body]
       end
     end


### PR DESCRIPTION
problem: So I am using font_assets along with sidekiq and it seems that sidekiq's web interface is changing the value of `env['PATH_INFO']` to a blank string, which then breaks things. 

caveat: I am not at expert at RACK so I am not sure that this fixes the problem at the root. Also, I am not really sure if sidekiq should be changing the `env`. 

This is a first attempt at a fix. The test suite passes. I am not sure if you want to add a test case for apps that change the `env`, so I didn't add one. 

Another possible fix might be to allow for `env['PATH_INFO']` to hold a blank string but then again, I am not exactly sure what exactly the culprit is. 
