### PR TITLE
Only intercept preflight requests for fonts, and bonus `insert_target` configuration option

### DIFF
--- a/lib/font_assets/middleware.rb
+++ b/lib/font_assets/middleware.rb
@@ -24,7 +24,11 @@ module FontAssets
       @ssl_request = Rack::Request.new(env).scheme == "https"
       # intercept the "preflight" request
       if env["REQUEST_METHOD"] == "OPTIONS"
-        return [200, access_control_headers, []]
+        if ext = extension(env["PATH_INFO"]) and font_asset?(ext)
+          return [200, access_control_headers, []]
+        else
+          return @app.call(env)
+        end
       else
         code, headers, body = @app.call(env)
         set_headers! headers, body, env["PATH_INFO"]

--- a/lib/font_assets/middleware.rb
+++ b/lib/font_assets/middleware.rb
@@ -61,7 +61,7 @@ module FontAssets
       @options[:allow_ssl]
     end
 
-    def extension(path)
+    def extension(path='')
       "." + path.split("?").first.split(".").last
     end
 

--- a/lib/font_assets/middleware.rb
+++ b/lib/font_assets/middleware.rb
@@ -62,8 +62,9 @@ module FontAssets
     end
 
     def extension(path)
-      path ||= '/'
       "." + path.split("?").first.split(".").last
+    rescue
+      "."
     end
 
     def font_asset?(path)

--- a/lib/font_assets/middleware.rb
+++ b/lib/font_assets/middleware.rb
@@ -62,7 +62,7 @@ module FontAssets
     end
 
     def extension(path)
-      path ||= ''
+      path ||= '/'
       "." + path.split("?").first.split(".").last
     end
 

--- a/lib/font_assets/middleware.rb
+++ b/lib/font_assets/middleware.rb
@@ -61,7 +61,8 @@ module FontAssets
       @options[:allow_ssl]
     end
 
-    def extension(path='')
+    def extension(path)
+      path ||= ''
       "." + path.split("?").first.split(".").last
     end
 

--- a/lib/font_assets/railtie.rb
+++ b/lib/font_assets/railtie.rb
@@ -8,7 +8,7 @@ module FontAssets
       config.font_assets.origin ||= "*"
       config.font_assets.options ||= { allow_ssl: true }
 
-      insert_target = if defined?(ActionDispatch::Static)
+      config.font_assets.insert_target ||= if defined?(ActionDispatch::Static)
         'ActionDispatch::Static'
       else
         'Rack::Runtime'

--- a/lib/font_assets/railtie.rb
+++ b/lib/font_assets/railtie.rb
@@ -14,7 +14,10 @@ module FontAssets
         'Rack::Runtime'
       end
 
-      app.middleware.insert_before insert_target, FontAssets::Middleware, config.font_assets.origin, config.font_assets.options
+      app.middleware.insert_before config.font_assets.insert_target,
+        FontAssets::Middleware,
+        config.font_assets.origin,
+        config.font_assets.options
     end
   end
 end


### PR DESCRIPTION
Sorry this is a two in one
- Preflight requests are only intercepted for font assets. Makes the gem compatible with `Rack::Cors` or any other setup that also requires special preflight responses
- Added an `insert_target` option so that you can choose which middleware you want `font_assets` to be inserted before
