### PR TITLE
Handle cases when PATH_INFO is nil or blank

### DIFF
--- a/lib/font_assets/middleware.rb
+++ b/lib/font_assets/middleware.rb
@@ -58,7 +58,11 @@ module FontAssets
     end
 
     def extension(path)
-      "." + path.split("?").first.split(".").last
+      if path.nil? || path.length == 0
+        nil
+      else
+        "." + path.split("?").first.split(".").last
+      end
     end
 
     def font_asset?(path)

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -104,6 +104,36 @@ describe FontAssets::Middleware do
         its(['Content-Type']) { should == 'text/plain' }
       end
     end
+
+    context 'when PATH_INFO is nil' do
+      let(:app) { load_app }
+      let(:response) { request app, '/', 'PATH_INFO' => nil }
+
+      context 'the response headers' do
+        subject { response[1] }
+
+        its(["Access-Control-Allow-Headers"]) { should be_nil }
+        its(["Access-Control-Max-Age"]) { should be_nil }
+        its(['Access-Control-Allow-Methods']) { should be_nil }
+        its(['Access-Control-Allow-Origin']) { should be_nil }
+        its(['Content-Type']) { should == 'text/plain' }
+      end
+    end
+
+    context 'when PATH_INFO is empty string' do
+      let(:app) { load_app }
+      let(:response) { request app, '/', 'PATH_INFO' => ''}
+
+      context 'the response headers' do
+        subject { response[1] }
+
+        its(["Access-Control-Allow-Headers"]) { should be_nil }
+        its(["Access-Control-Max-Age"]) { should be_nil }
+        its(['Access-Control-Allow-Methods']) { should be_nil }
+        its(['Access-Control-Allow-Origin']) { should be_nil }
+        its(['Content-Type']) { should == 'text/plain' }
+      end
+    end
   end
 
   context 'for OPTIONS requests' do


### PR DESCRIPTION
According to the Rack Spec (http://rack.rubyforge.org/doc/SPEC.html)
PATH_INFO can be an empty string
