### PR TITLE
Only intercept preflight requests for fonts

### DIFF
--- a/lib/font_assets/middleware.rb
+++ b/lib/font_assets/middleware.rb
@@ -24,7 +24,11 @@ module FontAssets
       @ssl_request = Rack::Request.new(env).scheme == "https"
       # intercept the "preflight" request
       if env["REQUEST_METHOD"] == "OPTIONS"
-        return [200, access_control_headers, []]
+        if ext = extension(env["PATH_INFO"]) and font_asset?(ext)
+          return [200, access_control_headers, []]
+        else
+          return @app.call(env)
+        end
       else
         code, headers, body = @app.call(env)
         set_headers! headers, body, env["PATH_INFO"]

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -136,7 +136,7 @@ describe FontAssets::Middleware do
     end
   end
 
-  context 'for OPTIONS requests' do
+  context 'for OPTIONS requests to a font' do
     let(:app) { load_app 'http://test.options' }
     let(:response) { request app, '/test.ttf', :method => 'OPTIONS' }
 
@@ -156,6 +156,29 @@ describe FontAssets::Middleware do
     context 'the response body' do
       subject { response[2] }
       it { should be_empty }
+    end
+  end
+
+  context 'for OPTIONS requests to a non-font' do
+    let(:app) { load_app 'http://test.options' }
+    let(:response) { request app, '/test.json', :method => 'OPTIONS' }
+
+    context 'the response headers' do
+      subject { response[1] }
+
+      its(["Access-Control-Allow-Headers"]) { should_not == "x-requested-with" }
+      its(["Access-Control-Max-Age"]) { should_not == "3628800" }
+      its(['Access-Control-Allow-Methods']) { should_not == 'GET' }
+      its(['Access-Control-Allow-Origin']) { should_not == 'http://test.options' }
+
+      it 'should contain a Content-Type' do
+        subject['Content-Type'].should_not be_nil
+      end
+    end
+
+    context 'the response body' do
+      subject { response[2] }
+      it { should_not be_empty }
     end
   end
 


### PR DESCRIPTION
I cherry-picked @snikch's commit in #18 that was relevant to this specific problem, then wrote a spec for it based on the existing options request spec for a font.  Resolves #32.