### PR TITLE
defined?(ActionDispatch::Static) is always true

### DIFF
--- a/lib/font_assets/railtie.rb
+++ b/lib/font_assets/railtie.rb
@@ -8,7 +8,7 @@ module FontAssets
       config.font_assets.origin ||= "*"
       config.font_assets.options ||= { allow_ssl: true }
 
-      insert_target = if defined?(ActionDispatch::Static)
+      insert_target = if app.config.serve_static_files
         'ActionDispatch::Static'
       else
         'Rack::Runtime'


### PR DESCRIPTION
Instead check if we are serving static files, as that will explicitly means ActionDispatch::Static is loaded.
