### PR TITLE
Remove options http method interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ two things:
 * Responds with "proper" mime types for woff, eot, tff, and svg font files, and
 * Sets Access-Control-Allow-Origin response headers for font assets, which Firefox requires for cross domain fonts.
 
-In addition, it will also respond to the pre-flight OPTIONS requests made by
-supporting browsers (Firefox).
-
 Install
 -------
 
@@ -82,23 +79,6 @@ Connection: close
 
 In it, you can see where this middleware has injected the `Content-Type` and
 `Access-Control-*` headers into the response.
-
-And below is an example OPTIONS request response:
-
-```
-$ curl -i -X OPTIONS http://www.codeschool.com/
-HTTP/1.1 200 OK
-Server: nginx
-Date: Wed, 18 Jan 2012 04:13:25 GMT
-Connection: keep-alive
-Access-Control-Allow-Origin: http://www.codeschool.com
-Access-Control-Allow-Methods: GET
-Access-Control-Allow-Headers: x-requested-with
-Access-Control-Max-Age: 3628800
-Vary: Accept-Encoding
-X-Rack-Cache: invalidate, pass
-Content-Length: 0
-```
 
 License
 -------

--- a/lib/font_assets/middleware.rb
+++ b/lib/font_assets/middleware.rb
@@ -22,14 +22,9 @@ module FontAssets
 
     def call(env)
       @ssl_request = Rack::Request.new(env).scheme == "https"
-      # intercept the "preflight" request
-      if env["REQUEST_METHOD"] == "OPTIONS"
-        return [200, access_control_headers, []]
-      else
-        code, headers, body = @app.call(env)
-        set_headers! headers, body, env["PATH_INFO"]
-        [code, headers, body]
-      end
+      code, headers, body = @app.call(env)
+      set_headers! headers, body, env["PATH_INFO"]
+      [code, headers, body]
     end
 
 

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -136,30 +136,6 @@ describe FontAssets::Middleware do
     end
   end
 
-  context 'for OPTIONS requests' do
-    let(:app) { load_app 'http://test.options' }
-    let(:response) { request app, '/test.ttf', :method => 'OPTIONS' }
-
-    context 'the response headers' do
-      subject { response[1] }
-
-      its(["Access-Control-Allow-Headers"]) { should == "x-requested-with" }
-      its(["Access-Control-Max-Age"]) { should == "3628800" }
-      its(['Access-Control-Allow-Methods']) { should == 'GET' }
-      its(['Access-Control-Allow-Origin']) { should == 'http://test.options' }
-
-      it 'should not contain a Content-Type' do
-        subject['Content-Type'].should be_nil
-      end
-    end
-
-    context 'the response body' do
-      subject { response[2] }
-      it { should be_empty }
-    end
-  end
-
-
   private
 
 


### PR DESCRIPTION
Explicitly returning a 200 response code when `env["REQUEST_METHOD"] == OPTIONS` can introduce a dependency in the order an application's middleware is executed.

Specifically, if a different intended response for an OPTIONS request is implemented (like a 403) in another piece of middleware, it MUST come before `font_assets` middleware in the stack or it will never get executed.

Happy to discuss further : ) and apologies if I am missing the reason why this OPTIONS request interception if necessary for `font_assets` to work properly. Please enlighten! Thanks!