### PR TITLE
Rails 5: Removal of middleware deprecation warning

### DIFF
--- a/lib/font_assets/railtie.rb
+++ b/lib/font_assets/railtie.rb
@@ -9,9 +9,9 @@ module FontAssets
       config.font_assets.options ||= { allow_ssl: true }
 
       insert_target = if defined?(ActionDispatch::Static)
-        'ActionDispatch::Static'
+        ActionDispatch::Static
       else
-        'Rack::Runtime'
+        Rack::Runtime
       end
 
       app.middleware.insert_before insert_target, FontAssets::Middleware, config.font_assets.origin, config.font_assets.options


### PR DESCRIPTION
```
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change them to actual class references.

For example:

  "ActionDispatch::Static" => ActionDispatch::Static
```
