### PR TITLE
Remove deprecated gemspec options

### DIFF
--- a/font_assets.gemspec
+++ b/font_assets.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Improve font serving in Rails 3.1}
   s.description = %q{Improve font serving in Rails 3.1}
 
-  s.rubyforge_project = "font_assets"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
This is now warning with latest rubygems and will break in future versions